### PR TITLE
[35] Shorthand `gib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ GitBlend is a versatile tool designed to simplify your Git and GitHub workflows.
   - Optionally skips repositories with uncommitted changes or those not on the `main` branch.
 
 - **Commit Management**: Simplify the process of creating commits with the `create-commit` command. This includes:
+
   - Adding all files to the commit with the `--add` flag.
   - Creating commits even when there are no changes using the `--allow-empty` flag.
 
@@ -63,6 +64,13 @@ This script will:
 ## Usage
 
 After installation, you can use the `gitblend` command from your terminal, followed by the desired command.
+
+> **Note**: You can also use the shorthand `gib` instead of `gitblend` for all commands. For example:
+>
+> ```bash
+> gib list-tags
+> gib create-tag v1.2.0 --message "Release v1.2.0"
+> ```
 
 ### Available Commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ toml = "^0.10.2"
 
 [tool.poetry.scripts]
 gitblend = "gitblend.cli:main"
+gib = "gitblend.cli:main"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"


### PR DESCRIPTION
# Description

`gitblend` is to long, a shorter version is more user friendly and given that `gb` may be taken if they have `gh` for git actions then we only have the `gib` option

# Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

# Changes Made

* Updated the configuration to also be able to use `gib` as entry point command
* Updated readme with a note on shorthand availability

# Screenshots (if applicable)

- If there are any UI or CLI changes, provide relevant screenshots.

# Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes and verified that they work as expected.
- [x] I have updated the documentation (if applicable).
- [x] My changes do not introduce any new warnings or errors.

# Additional Notes

Closes #35 
