### PR TITLE
[39] Option to sign commits on commit creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ After installation, you can use the `gitblend` command from your terminal, follo
 
 #### Commit Management
 
-- `gitblend commit --message "<commit_message>" [--add]`: Create a new Git commit with a message. Use `--add` to stage all files before committing.
+- `gitblend commit --message "<commit_message>" [--add] [--sign]`: Create a new Git commit with a message. Use `--add` to stage all files before committing. Use `--sign` to sign the commit with your GPG key.
 
 #### General
 

--- a/gitblend/commands/commits/create.py
+++ b/gitblend/commands/commits/create.py
@@ -11,9 +11,10 @@ def run(args):
         print("✅ All files added to the commit.")
 
     message = args.message
-    subprocess.run(
-        [GIT_EXECUTABLE, "commit", "--allow-empty", "-m", message],
-        text=True,
-        check=True,
-    )
+    commit_command = [GIT_EXECUTABLE, "commit", "--allow-empty", "-m", message]
+
+    if args.sign:
+        commit_command.append("--gpg-sign")
+
+    subprocess.run(commit_command, text=True, check=True)
     print(f"✅ Commit created successfully with message: '{message}'")

--- a/gitblend/commands/commits/entrypoints.py
+++ b/gitblend/commands/commits/entrypoints.py
@@ -14,6 +14,12 @@ def add_create_commit_command(subparsers):
         action="store_true",
         help="Add all files to the commit (equivalent to 'git add .')",
     )
+    create_commit_parser.add_argument(
+        "-s",
+        "--sign",
+        action="store_true",
+        help="Sign the commit with the user's GPG key",
+    )
     create_commit_parser.set_defaults(func=create.run)
 
 

--- a/tests/commands/commits/test_create_commit.py
+++ b/tests/commands/commits/test_create_commit.py
@@ -13,7 +13,7 @@ class TestCreateCommitCommand(unittest.TestCase):
     def test_create_commit_success(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
 
-        args = MagicMock(message="Initial commit", add=False)
+        args = MagicMock(message="Initial commit", add=False, sign=False)
 
         with patch("builtins.print") as mock_print:
             run(args)
@@ -48,7 +48,7 @@ class TestCreateCommitCommand(unittest.TestCase):
     def test_create_commit_with_add(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
 
-        args = MagicMock(message="Initial commit", add=True)
+        args = MagicMock(message="Initial commit", add=True, sign=False)
 
         with patch("builtins.print") as mock_print:
             run(args)
@@ -58,6 +58,32 @@ class TestCreateCommitCommand(unittest.TestCase):
             )
             mock_run.assert_any_call(
                 [GIT_EXECUTABLE, "commit", "--allow-empty", "-m", "Initial commit"],
+                text=True,
+                check=True,
+            )
+            mock_print.assert_any_call("✅ All files added to the commit.")
+            mock_print.assert_any_call(
+                "✅ Commit created successfully with message: 'Initial commit'"
+            )
+
+    @patch("subprocess.run")
+    def test_create_commit_with_sign(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+
+        args = MagicMock(message="Initial commit", sign=True)
+
+        with patch("builtins.print") as mock_print:
+            run(args)
+
+            mock_run.assert_any_call(
+                [
+                    GIT_EXECUTABLE,
+                    "commit",
+                    "--allow-empty",
+                    "-m",
+                    "Initial commit",
+                    "--gpg-sign",
+                ],
                 text=True,
                 check=True,
             )


### PR DESCRIPTION
# Description

Somepeople (like me) like to sign their commits so they can add even more limitations on the repositories

# Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

# Changes Made

* Add new option `-s` to the commit command
* Updated README with the new command option

# Screenshots (if applicable)

<img width="644" alt="Screenshot 2025-04-19 at 10 32 06" src="https://github.com/user-attachments/assets/494f01a0-f3ca-438c-a175-2533431f405e" />


# Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes and verified that they work as expected.
- [x] I have updated the documentation (if applicable).
- [x] My changes do not introduce any new warnings or errors.

# Additional Notes

Closes #39 
