### PR TITLE
Commit configuration + setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,14 @@ After installation, you can use the `gitblend` command from your terminal, follo
 #### General
 
 - `gitblend --help`: Show help information for the GitBlend CLI.
+- `gitblend setup [--force]`: Interactively create the [configuration file](#configuration). Use `--force` to overwrite an existing one without asking.
 - `gitblend self-update`: Pull the latest changes from the source repo and reinstall GitBlend.
 
 ## Configuration
 
 GitBlend reads an optional configuration file at `~/.gitblend.toml` where you can set default behavior, so you don't have to pass the same flags on every invocation.
+
+The easiest way to create it is running `gib setup`, which asks a few yes/no questions and writes the file for you (the install script also offers this on a fresh install). Alternatively, create it by hand:
 
 ```toml
 [commit]

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ After installation, you can use the `gitblend` command from your terminal, follo
 
 #### Commit Management
 
-- `gitblend commit "<commit_message>" [--add] [--sign]`: Create a new Git commit with a message (also accepted via `-m`/`--message`). Use `--add` to stage all files before committing. Use `--sign` to sign the commit with your GPG key. Both flags can be enabled by default via the [configuration file](#configuration).
+- `gitblend commit "<commit_message>" [--add] [--sign] [--allow-empty]`: Create a new Git commit with a message (also accepted via `-m`/`--message`). Use `--add` to stage all files before committing, `--sign` to sign the commit with your GPG key, and `--allow-empty` to create a commit even when there are no changes. All three flags can be enabled by default via the [configuration file](#configuration).
 - `gitblend revert <number_of_commits> [--push]`: Revert the last specified number of commits. Use `--push` to push the changes to the remote repository after reverting.
 
 #### General
@@ -107,8 +107,9 @@ GitBlend reads an optional configuration file at `~/.gitblend.toml` where you ca
 
 ```toml
 [commit]
-add = true  # Always stage all files before committing (same as --add)
-sign = true # Always sign commits with your GPG key (same as --sign)
+add = true         # Always stage all files before committing (same as --add)
+sign = true        # Always sign commits with your GPG key (same as --sign)
+allow_empty = true # Always allow empty commits (same as --allow-empty)
 ```
 
 With the configuration above, these two commands are equivalent:

--- a/README.md
+++ b/README.md
@@ -93,13 +93,30 @@ After installation, you can use the `gitblend` command from your terminal, follo
 
 #### Commit Management
 
-- `gitblend commit --message "<commit_message>" [--add] [--sign]`: Create a new Git commit with a message. Use `--add` to stage all files before committing. Use `--sign` to sign the commit with your GPG key.
+- `gitblend commit "<commit_message>" [--add] [--sign]`: Create a new Git commit with a message (also accepted via `-m`/`--message`). Use `--add` to stage all files before committing. Use `--sign` to sign the commit with your GPG key. Both flags can be enabled by default via the [configuration file](#configuration).
 - `gitblend revert <number_of_commits> [--push]`: Revert the last specified number of commits. Use `--push` to push the changes to the remote repository after reverting.
 
 #### General
 
 - `gitblend --help`: Show help information for the GitBlend CLI.
 - `gitblend self-update`: Pull the latest changes from the source repo and reinstall GitBlend.
+
+## Configuration
+
+GitBlend reads an optional configuration file at `~/.gitblend.toml` where you can set default behavior, so you don't have to pass the same flags on every invocation.
+
+```toml
+[commit]
+add = true  # Always stage all files before committing (same as --add)
+sign = true # Always sign commits with your GPG key (same as --sign)
+```
+
+With the configuration above, these two commands are equivalent:
+
+```bash
+gib commit "My commit message"
+gib commit -s -a -m "My commit message"
+```
 
 ## Uninstallation
 

--- a/gitblend/cli.py
+++ b/gitblend/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from gitblend.commands import self_update, update_all, version
+from gitblend.commands import self_update, setup, update_all, version
 from gitblend.commands.commits.entrypoints import add_commits_commands
 from gitblend.commands.remote_management.entrypoints import (
     add_remote_management_commands,
@@ -33,6 +33,18 @@ def add_version_command(subparsers):
     version_parser.set_defaults(func=version.run)
 
 
+def add_setup_command(subparsers):
+    setup_parser = subparsers.add_parser(
+        "setup", help="Interactively create the GitBlend configuration file"
+    )
+    setup_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing configuration file without asking",
+    )
+    setup_parser.set_defaults(func=setup.run)
+
+
 def add_self_update_command(subparsers):
     self_update_parser = subparsers.add_parser(
         "self-update", help="Update GitBlend to the latest version"
@@ -52,6 +64,7 @@ def main():
     add_remote_management_commands(subparsers)
 
     add_update_all_command(subparsers)
+    add_setup_command(subparsers)
     add_version_command(subparsers)
     add_self_update_command(subparsers)
 

--- a/gitblend/commands/commits/create.py
+++ b/gitblend/commands/commits/create.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 from gitblend.utils import GIT_EXECUTABLE, handle_git_errors
 
@@ -6,11 +7,18 @@ from gitblend.utils import GIT_EXECUTABLE, handle_git_errors
 @handle_git_errors
 def run(args):
     """Create a new Git commit with a message."""
+    message = args.message or getattr(args, "positional_message", None)
+    if not message:
+        print(
+            "❌ A commit message is required (pass it as an argument or with -m).",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
     if args.add:
         subprocess.run([GIT_EXECUTABLE, "add", "."], text=True, check=True)
         print("✅ All files added to the commit.")
 
-    message = args.message
     commit_command = [GIT_EXECUTABLE, "commit", "--allow-empty", "-m", message]
 
     if args.sign:

--- a/gitblend/commands/commits/create.py
+++ b/gitblend/commands/commits/create.py
@@ -19,7 +19,10 @@ def run(args):
         subprocess.run([GIT_EXECUTABLE, "add", "."], text=True, check=True)
         print("✅ All files added to the commit.")
 
-    commit_command = [GIT_EXECUTABLE, "commit", "--allow-empty", "-m", message]
+    commit_command = [GIT_EXECUTABLE, "commit", "-m", message]
+
+    if args.allow_empty:
+        commit_command.append("--allow-empty")
 
     if args.sign:
         commit_command.append("--gpg-sign")

--- a/gitblend/commands/commits/entrypoints.py
+++ b/gitblend/commands/commits/entrypoints.py
@@ -1,12 +1,21 @@
 from gitblend.commands.commits import create, revert
+from gitblend.config import load_config
 
 
 def add_create_commit_command(subparsers):
+    commit_config = load_config().get("commit", {})
+
     create_commit_parser = subparsers.add_parser(
         "commit", help="Create a new Git commit with a message"
     )
     create_commit_parser.add_argument(
-        "-m", "--message", type=str, required=True, help="The commit message"
+        "positional_message",
+        nargs="?",
+        metavar="message",
+        help="The commit message",
+    )
+    create_commit_parser.add_argument(
+        "-m", "--message", type=str, help="The commit message"
     )
     create_commit_parser.add_argument(
         "-a",
@@ -20,7 +29,11 @@ def add_create_commit_command(subparsers):
         action="store_true",
         help="Sign the commit with the user's GPG key",
     )
-    create_commit_parser.set_defaults(func=create.run)
+    create_commit_parser.set_defaults(
+        func=create.run,
+        add=bool(commit_config.get("add", False)),
+        sign=bool(commit_config.get("sign", False)),
+    )
 
 
 def add_revert_command(subparsers):

--- a/gitblend/commands/commits/entrypoints.py
+++ b/gitblend/commands/commits/entrypoints.py
@@ -29,10 +29,17 @@ def add_create_commit_command(subparsers):
         action="store_true",
         help="Sign the commit with the user's GPG key",
     )
+    create_commit_parser.add_argument(
+        "-e",
+        "--allow-empty",
+        action="store_true",
+        help="Allow creating a commit even when there are no changes",
+    )
     create_commit_parser.set_defaults(
         func=create.run,
         add=bool(commit_config.get("add", False)),
         sign=bool(commit_config.get("sign", False)),
+        allow_empty=bool(commit_config.get("allow_empty", False)),
     )
 
 

--- a/gitblend/commands/setup.py
+++ b/gitblend/commands/setup.py
@@ -1,0 +1,38 @@
+import os
+
+import toml
+
+from gitblend.config import CONFIG_PATH
+
+
+def prompt_yes_no(question):
+    """Ask a yes/no question and return the answer as a boolean."""
+    answer = input(f"{question} [y/N]: ").strip().lower()
+    return answer in ("y", "yes")
+
+
+def run(args):
+    """Interactively generate the GitBlend configuration file."""
+    if os.path.exists(CONFIG_PATH) and not args.force:
+        if not prompt_yes_no(f"⚠️ {CONFIG_PATH} already exists. Overwrite it?"):
+            print("Setup cancelled. Existing configuration left untouched.")
+            return
+
+    config = {
+        "commit": {
+            "add": prompt_yes_no(
+                "Always stage all files before committing (same as --add)?"
+            ),
+            "sign": prompt_yes_no(
+                "Always sign commits with your GPG key (same as --sign)?"
+            ),
+            "allow_empty": prompt_yes_no(
+                "Always allow empty commits (same as --allow-empty)?"
+            ),
+        }
+    }
+
+    with open(CONFIG_PATH, "w") as file:
+        toml.dump(config, file)
+
+    print(f"✅ Configuration written to {CONFIG_PATH}")

--- a/gitblend/config.py
+++ b/gitblend/config.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+import toml
+
+CONFIG_PATH = os.path.expanduser("~/.gitblend.toml")
+
+
+def load_config():
+    """Load the user configuration from ~/.gitblend.toml, if it exists."""
+    try:
+        with open(CONFIG_PATH, "r") as file:
+            return toml.load(file)
+    except FileNotFoundError:
+        return {}
+    except toml.TomlDecodeError as e:
+        print(f"⚠️ Ignoring invalid config file {CONFIG_PATH}: {e}", file=sys.stderr)
+        return {}

--- a/install.sh
+++ b/install.sh
@@ -42,4 +42,12 @@ echo "Repo path saved to $GITBLEND_CONFIG_DIR/repo_path"
 echo "Cleaning up..."
 rm -rf $DIST_DIR
 
+if [ ! -f "$HOME/.gitblend.toml" ] && [ -t 0 ]; then
+  read -r -p "No GitBlend configuration found. Create one now? [y/N]: " CREATE_CONFIG
+  case "$CREATE_CONFIG" in
+    [yY]|[yY][eE][sS]) gib setup ;;
+    *) echo "You can create it later by running 'gib setup'." ;;
+  esac
+fi
+
 echo "Installation completed."

--- a/tests/commands/commits/test_commits_entrypoints.py
+++ b/tests/commands/commits/test_commits_entrypoints.py
@@ -22,10 +22,11 @@ class TestCommitEntrypoints(unittest.TestCase):
         self.assertEqual(args.message, "Initial commit")
         self.assertFalse(args.add)
         self.assertFalse(args.sign)
+        self.assertFalse(args.allow_empty)
 
     @patch(
         "gitblend.commands.commits.entrypoints.load_config",
-        return_value={"commit": {"add": True, "sign": True}},
+        return_value={"commit": {"add": True, "sign": True, "allow_empty": True}},
     )
     def test_commit_flags_default_from_config(self, mock_config):
         parser = build_parser()
@@ -34,6 +35,7 @@ class TestCommitEntrypoints(unittest.TestCase):
         self.assertEqual(args.positional_message, "Initial commit")
         self.assertTrue(args.add)
         self.assertTrue(args.sign)
+        self.assertTrue(args.allow_empty)
 
     @patch("gitblend.commands.commits.entrypoints.load_config", return_value={})
     def test_commit_accepts_positional_message(self, mock_config):

--- a/tests/commands/commits/test_commits_entrypoints.py
+++ b/tests/commands/commits/test_commits_entrypoints.py
@@ -1,0 +1,48 @@
+import argparse
+import unittest
+from unittest.mock import patch
+
+from gitblend.commands.commits.entrypoints import add_commits_commands
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="gitblend")
+    subparsers = parser.add_subparsers(dest="command")
+    add_commits_commands(subparsers)
+    return parser
+
+
+class TestCommitEntrypoints(unittest.TestCase):
+
+    @patch("gitblend.commands.commits.entrypoints.load_config", return_value={})
+    def test_commit_flags_default_to_false_without_config(self, mock_config):
+        parser = build_parser()
+        args = parser.parse_args(["commit", "-m", "Initial commit"])
+
+        self.assertEqual(args.message, "Initial commit")
+        self.assertFalse(args.add)
+        self.assertFalse(args.sign)
+
+    @patch(
+        "gitblend.commands.commits.entrypoints.load_config",
+        return_value={"commit": {"add": True, "sign": True}},
+    )
+    def test_commit_flags_default_from_config(self, mock_config):
+        parser = build_parser()
+        args = parser.parse_args(["commit", "Initial commit"])
+
+        self.assertEqual(args.positional_message, "Initial commit")
+        self.assertTrue(args.add)
+        self.assertTrue(args.sign)
+
+    @patch("gitblend.commands.commits.entrypoints.load_config", return_value={})
+    def test_commit_accepts_positional_message(self, mock_config):
+        parser = build_parser()
+        args = parser.parse_args(["commit", "Initial commit"])
+
+        self.assertEqual(args.positional_message, "Initial commit")
+        self.assertIsNone(args.message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/commands/commits/test_create_commit.py
+++ b/tests/commands/commits/test_create_commit.py
@@ -67,6 +67,40 @@ class TestCreateCommitCommand(unittest.TestCase):
             )
 
     @patch("subprocess.run")
+    def test_create_commit_without_message(self, mock_run):
+        args = MagicMock(message=None, positional_message=None)
+
+        with patch("builtins.print") as mock_print:
+            with self.assertRaises(SystemExit):
+                run(args)
+
+            mock_print.assert_any_call(
+                "❌ A commit message is required (pass it as an argument or with -m).",
+                file=sys.stderr,
+            )
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_create_commit_with_positional_message(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+
+        args = MagicMock(
+            message=None, positional_message="Initial commit", add=False, sign=False
+        )
+
+        with patch("builtins.print") as mock_print:
+            run(args)
+
+            mock_run.assert_called_once_with(
+                [GIT_EXECUTABLE, "commit", "--allow-empty", "-m", "Initial commit"],
+                text=True,
+                check=True,
+            )
+            mock_print.assert_any_call(
+                "✅ Commit created successfully with message: 'Initial commit'"
+            )
+
+    @patch("subprocess.run")
     def test_create_commit_with_sign(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
 

--- a/tests/commands/commits/test_create_commit.py
+++ b/tests/commands/commits/test_create_commit.py
@@ -13,13 +13,15 @@ class TestCreateCommitCommand(unittest.TestCase):
     def test_create_commit_success(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
 
-        args = MagicMock(message="Initial commit", add=False, sign=False)
+        args = MagicMock(
+            message="Initial commit", add=False, sign=False, allow_empty=False
+        )
 
         with patch("builtins.print") as mock_print:
             run(args)
 
             mock_run.assert_called_once_with(
-                [GIT_EXECUTABLE, "commit", "--allow-empty", "-m", "Initial commit"],
+                [GIT_EXECUTABLE, "commit", "-m", "Initial commit"],
                 text=True,
                 check=True,
             )
@@ -48,7 +50,9 @@ class TestCreateCommitCommand(unittest.TestCase):
     def test_create_commit_with_add(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
 
-        args = MagicMock(message="Initial commit", add=True, sign=False)
+        args = MagicMock(
+            message="Initial commit", add=True, sign=False, allow_empty=False
+        )
 
         with patch("builtins.print") as mock_print:
             run(args)
@@ -57,7 +61,7 @@ class TestCreateCommitCommand(unittest.TestCase):
                 [GIT_EXECUTABLE, "add", "."], text=True, check=True
             )
             mock_run.assert_any_call(
-                [GIT_EXECUTABLE, "commit", "--allow-empty", "-m", "Initial commit"],
+                [GIT_EXECUTABLE, "commit", "-m", "Initial commit"],
                 text=True,
                 check=True,
             )
@@ -85,14 +89,18 @@ class TestCreateCommitCommand(unittest.TestCase):
         mock_run.return_value = MagicMock(returncode=0)
 
         args = MagicMock(
-            message=None, positional_message="Initial commit", add=False, sign=False
+            message=None,
+            positional_message="Initial commit",
+            add=False,
+            sign=False,
+            allow_empty=False,
         )
 
         with patch("builtins.print") as mock_print:
             run(args)
 
             mock_run.assert_called_once_with(
-                [GIT_EXECUTABLE, "commit", "--allow-empty", "-m", "Initial commit"],
+                [GIT_EXECUTABLE, "commit", "-m", "Initial commit"],
                 text=True,
                 check=True,
             )
@@ -104,7 +112,9 @@ class TestCreateCommitCommand(unittest.TestCase):
     def test_create_commit_with_sign(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
 
-        args = MagicMock(message="Initial commit", sign=True)
+        args = MagicMock(
+            message="Initial commit", add=True, sign=True, allow_empty=True
+        )
 
         with patch("builtins.print") as mock_print:
             run(args)
@@ -113,9 +123,9 @@ class TestCreateCommitCommand(unittest.TestCase):
                 [
                     GIT_EXECUTABLE,
                     "commit",
-                    "--allow-empty",
                     "-m",
                     "Initial commit",
+                    "--allow-empty",
                     "--gpg-sign",
                 ],
                 text=True,

--- a/tests/commands/test_setup.py
+++ b/tests/commands/test_setup.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+import toml
+
+from gitblend.commands.setup import run
+from gitblend.config import CONFIG_PATH
+
+
+class TestSetupCommand(unittest.TestCase):
+
+    @patch("os.path.exists", return_value=False)
+    @patch("builtins.input", side_effect=["y", "n", "yes"])
+    def test_setup_writes_answers_to_config(self, mock_input, mock_exists):
+        args = MagicMock(force=False)
+        opened = mock_open()
+
+        with patch("builtins.open", opened):
+            with patch("builtins.print") as mock_print:
+                run(args)
+
+        written = "".join(call.args[0] for call in opened().write.call_args_list)
+        self.assertEqual(
+            toml.loads(written),
+            {"commit": {"add": True, "sign": False, "allow_empty": True}},
+        )
+        mock_print.assert_any_call(f"✅ Configuration written to {CONFIG_PATH}")
+
+    @patch("os.path.exists", return_value=True)
+    @patch("builtins.input", return_value="n")
+    def test_setup_aborts_when_overwrite_declined(self, mock_input, mock_exists):
+        args = MagicMock(force=False)
+
+        with patch("builtins.open") as mock_file:
+            with patch("builtins.print") as mock_print:
+                run(args)
+
+        mock_file.assert_not_called()
+        mock_print.assert_any_call(
+            "Setup cancelled. Existing configuration left untouched."
+        )
+
+    @patch("os.path.exists", return_value=True)
+    @patch("builtins.input", side_effect=["n", "n", "n"])
+    def test_setup_force_skips_overwrite_prompt(self, mock_input, mock_exists):
+        args = MagicMock(force=True)
+        opened = mock_open()
+
+        with patch("builtins.open", opened):
+            with patch("builtins.print"):
+                run(args)
+
+        written = "".join(call.args[0] for call in opened().write.call_args_list)
+        self.assertEqual(
+            toml.loads(written),
+            {"commit": {"add": False, "sign": False, "allow_empty": False}},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import mock_open, patch
+
+from gitblend.config import load_config
+
+
+class TestLoadConfig(unittest.TestCase):
+
+    def test_missing_config_returns_empty_dict(self):
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            self.assertEqual(load_config(), {})
+
+    def test_valid_config_is_loaded(self):
+        config_content = "[commit]\nsign = true\nadd = true\n"
+        with patch("builtins.open", mock_open(read_data=config_content)):
+            config = load_config()
+
+        self.assertEqual(config, {"commit": {"sign": True, "add": True}})
+
+    def test_invalid_config_is_ignored(self):
+        with patch("builtins.open", mock_open(read_data="not [ valid toml")):
+            with patch("builtins.print") as mock_print:
+                config = load_config()
+
+        self.assertEqual(config, {})
+        mock_print.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

Adds ability to define if you want the commits with the `secure`, `allow_empty` & `add` added automatically to every commit. Also adds a new command to generate the configuration file easier

# Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

# Changes Made

- Read configuration from file
- Generate configuration file command
- Added test
- Updated README

# Screenshots (if applicable)

- If there are any UI or CLI changes, provide relevant screenshots.

# Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes and verified that they work as expected.
- [x] I have updated the documentation (if applicable).
- [x] My changes do not introduce any new warnings or errors.