### PR TITLE
[Bug] Version command

### DIFF
--- a/gitblend/commands/version.py
+++ b/gitblend/commands/version.py
@@ -1,10 +1,6 @@
-import toml
+from importlib.metadata import version as get_version
 
 
 def run(args):
     """Display the current version of GitBlend."""
-    pyproject_path = "pyproject.toml"
-    with open(pyproject_path, "r") as file:
-        pyproject_data = toml.load(file)
-    version = pyproject_data["tool"]["poetry"]["version"]
-    print(f"GitBlend version {version}")
+    print(f"GitBlend version {get_version('gitblend')}")

--- a/tests/commands/test_version.py
+++ b/tests/commands/test_version.py
@@ -1,14 +1,10 @@
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
 from gitblend.commands import version
 
 
 def test_version_run():
-    mock_pyproject_content = """[tool.poetry]
-name = "gitblend"
-version = "0.1.0"
-"""
-    with patch("builtins.open", mock_open(read_data=mock_pyproject_content)):
+    with patch("gitblend.commands.version.get_version", return_value="0.1.0"):
         with patch("builtins.print") as mock_print:
             version.run(None)
             mock_print.assert_called_once_with("GitBlend version 0.1.0")


### PR DESCRIPTION
# Description

It reads `pyproject.toml` via a relative path, which would break gib version when run from a directory other than the repo after a pipx install.

# Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

# Changes Made

* Replace to read version from metadata

# Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md).
- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes and verified that they work as expected.
- [x] I have updated the documentation (if applicable).
- [x] My changes do not introduce any new warnings or errors.
